### PR TITLE
GH-49 associated domain support

### DIFF
--- a/addition/external_views.py
+++ b/addition/external_views.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from rest_framework import views
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+
+class AppleAppSiteAssociationView(views.APIView):
+    permission_classes = [AllowAny]
+
+    @staticmethod
+    def get(request):
+        return Response(settings.APPLE_APP_SITE_ASSOCIATION)

--- a/bakus_service/settings.py
+++ b/bakus_service/settings.py
@@ -150,3 +150,9 @@ TRANSMISSION_HOST = "localhost"
 TRANSMISSION_PORT = 9091
 TRANSMISSION_USERNAME = "test"
 TRANSMISSION_PASSWORD = "test"
+
+# Apple Associated Domain support
+# more info at:
+# https://developer.apple.com/documentation/xcode/supporting-associated-domains#Add-the-Associated-Domains-Entitlement-to-Your-App
+
+APPLE_APP_SITE_ASSOCIATION = {"test-field": "testing"}

--- a/bakus_service/urls.py
+++ b/bakus_service/urls.py
@@ -17,7 +17,7 @@ from django.contrib import admin
 from django.urls import include, path
 from knox import views as knox_views
 
-from addition import views
+from addition import external_views, views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -27,4 +27,10 @@ urlpatterns = [
     path("api/v1/auth/login/", views.LoginView.as_view(), name="knox_login"),
     path("api/v1/auth/logout/", knox_views.LogoutView.as_view(), name="knox_logout"),
     path("api/v1/auth/logoutall/", knox_views.LogoutAllView.as_view(), name="knox_logoutall"),
+    # External requirements
+    path(
+        ".well-known/apple-app-site-association",
+        external_views.AppleAppSiteAssociationView.as_view(),
+        name="apple-app-site-association",
+    ),
 ]

--- a/tests/addition/external_apple_test.py
+++ b/tests/addition/external_apple_test.py
@@ -1,0 +1,32 @@
+import pytest
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+# AASA - Apple App Site Association
+
+
+def test_aasa_url_set_properly():
+    assert reverse("apple-app-site-association") == "/.well-known/apple-app-site-association"
+
+
+@pytest.mark.django_db
+def test_aasa_content(api_client):
+    response = api_client.get(reverse("apple-app-site-association"))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {"test-field": "testing"}
+
+
+NEW_AASA_CONTENT = {
+    "test-file-field": {
+        "foo": "bar",
+    }
+}
+
+
+@pytest.mark.django_db
+@override_settings(APPLE_APP_SITE_ASSOCIATION=NEW_AASA_CONTENT)
+def test_aasa_custom(api_client):
+    response = api_client.get(reverse("apple-app-site-association"))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == NEW_AASA_CONTENT


### PR DESCRIPTION
Add support for setting the JSON object provided to Apple App Site Association.

* resolves #49