### PR TITLE
GH-51 improper addition progress

### DIFF
--- a/addition/clients.py
+++ b/addition/clients.py
@@ -38,10 +38,10 @@ class Transmission:
         files = [cls.format_file(f) for f in torrent.files()]
         files.sort(key=lambda f: f.name)
         return models.Addition(
-            id=torrent.id,
+            id=str(torrent.id),
             state=enums.State.DOWNLOADING,
             name=torrent.name,
-            progress=torrent.progress,
+            progress=torrent.progress / 100,
             files=files,
         )
 

--- a/tests/addition/demo_get_list_test.py
+++ b/tests/addition/demo_get_list_test.py
@@ -10,7 +10,7 @@ def test_demo_get_list(demo_api_client):
     response = demo_api_client.get(reverse("addition-list"))
     assert response.status_code == status.HTTP_200_OK
     expected = [
-        test_models.Torrent("demo_addition_1", "demo_addition_1", 0.5).get_json(include_files=False),
+        test_models.Torrent("demo_addition_1", "demo_addition_1", 50.0).get_json(include_files=False),
         test_models.Download("demo_addition_2").get_json(),
     ]
     assert response.data.get("count") == len(expected)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,12 +5,12 @@ TORRENT_DICT = {
     "1": Torrent(
         id="1",
         name="test_torrent_1",
-        progress=0.05,
+        progress=5.0,
     ),
     "2": Torrent(
         id="2",
         name="test_torrent_2",
-        progress=0.10,
+        progress=10.0,
     ),
 }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,11 @@ from addition import enums
 
 @define
 class Torrent:
+    """
+    Torrent represents the data that would come out of the Transmission-RPC client.
+    It has helper functions that generate the expected output in the endpoint
+    """
+
     id: str
     name: str
     progress: float
@@ -32,7 +37,7 @@ class Torrent:
             "id": self.id,
             "state": enums.State.DOWNLOADING,
             "name": self.name,
-            "progress": self.progress,
+            "progress": self.progress / 100,
             "files": [
                 {
                     "name": file.name,


### PR DESCRIPTION
Transmission RPC reports progress in `0.0` to `100.0`. Bakus uses `0.0` to `1.0`. This corrects the usage of the Transmission RPC value.

* resolves #51 