### PR TITLE
GH-9 addition detail endpoint

### DIFF
--- a/addition/errors.py
+++ b/addition/errors.py
@@ -1,0 +1,6 @@
+class ModelException(Exception):
+    """Base Exception for models"""
+
+
+class DoesNotExist(ModelException):
+    """Exception for when instance does not exist"""

--- a/addition/filters.py
+++ b/addition/filters.py
@@ -34,13 +34,13 @@ class AttributeFilter(BaseFilterBackend):
         return params.split()
 
     # TODO: make this less hackish by having the filter value types align with the object field
-    def filter_queryset(self, request, queryset: models.ObjectSet, view) -> models.ObjectSet:
+    def filter_queryset(self, request, queryset: models.AdditionSet, view) -> models.AdditionSet:
         filters = self.get_filters(view, request)
         if not filters:
             return queryset
         return queryset.filter(**filters)
 
-    def get_template_context(self, request, queryset: models.ObjectSet, view) -> dict:
+    def get_template_context(self, request, queryset: models.AdditionSet, view) -> dict:
         raw_fields = self.get_fields(view)
         filters = self.get_filters(view, request)
         fields = []

--- a/addition/models.py
+++ b/addition/models.py
@@ -22,6 +22,7 @@ class Addition:
     name: str
     progress: float
     state: enums.State
+    delete: typing.Callable
 
     id: uuid.UUID = field()
 

--- a/addition/views.py
+++ b/addition/views.py
@@ -73,11 +73,16 @@ class AdditionListView(generics.ListCreateAPIView):
         name="demo_addition",
         progress=0.0,
         files=[],
+        delete=lambda: None,
     )
 
     DEMO_LIST_INSTANCES = [
-        models.Addition(state=enums.State.DOWNLOADING, name="demo_addition_1", progress=0.5, files=[]),
-        models.Addition(state=enums.State.COMPLETED, name="demo_addition_2", progress=1.0, files=[]),
+        models.Addition(
+            state=enums.State.DOWNLOADING, name="demo_addition_1", progress=0.5, files=[], delete=lambda: None
+        ),
+        models.Addition(
+            state=enums.State.COMPLETED, name="demo_addition_2", progress=1.0, files=[], delete=lambda: None
+        ),
     ]
 
     def get_queryset(self) -> models.AdditionSet[models.Addition]:
@@ -96,7 +101,9 @@ class AdditionDetailView(generics.RetrieveDestroyAPIView):
     lookup_field = "id"
     serializer_class = AdditionSerializer
 
-    DEMO_INSTANCE = models.Addition(state=enums.State.DOWNLOADING, name="demo_addition_1", progress=0.5, files=[])
+    DEMO_INSTANCE = models.Addition(
+        state=enums.State.DOWNLOADING, name="demo_addition_1", progress=0.5, files=[], delete=lambda: None
+    )
 
     def get_queryset(self) -> models.AdditionSet[models.Addition]:
         if models.get_user_settings(self.request.user).demo:

--- a/bakus_service/urls.py
+++ b/bakus_service/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     # API v1
     path("api/v1/addition/", views.AdditionListView.as_view(), name="addition-list"),
+    path("api/v1/addition/<uuid:id>/", views.AdditionDetailView.as_view(), name="addition-detail"),
     path("api/v1/auth/account/", views.AccountView.as_view(), name="account-detail"),
     path("api/v1/auth/login/", views.LoginView.as_view(), name="knox_login"),
     path("api/v1/auth/logout/", knox_views.LogoutView.as_view(), name="knox_logout"),

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,1 @@
+from .hash import hash_id

--- a/common/hash.py
+++ b/common/hash.py
@@ -1,0 +1,6 @@
+import hashlib
+import uuid
+
+
+def hash_id(string: str) -> uuid.UUID:
+    return uuid.UUID(hashlib.blake2b(str.encode(string), digest_size=16).hexdigest())

--- a/tests/addition/delete_detail_test.py
+++ b/tests/addition/delete_detail_test.py
@@ -1,0 +1,33 @@
+import copy
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from common import hash_id
+from tests import test_constants
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("torrent_id", test_constants.TORRENT_DICT)
+def test_delete_detail_torrent(api_client, mock_transmission_client, torrent_id):
+    response = api_client.delete(reverse("addition-detail", args=[hash_id(torrent_id)]))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert len(mock_transmission_client.TORRENT_DICT) == len(test_constants.TORRENT_DICT) - 1
+    assert torrent_id not in mock_transmission_client.TORRENT_DICT
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("download", test_constants.DOWNLOADS)
+def test_delete_detail_files(api_client, mock_transmission_client, incoming_folder, download):
+    # don't include torrents
+    mock_transmission_client.TORRENT_DICT = {}
+    downloads = copy.deepcopy(test_constants.DOWNLOADS)
+    for d in downloads:
+        d.create_files(incoming_folder)
+
+    response = api_client.delete(reverse("addition-detail", args=[download.external_id]))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    updated_downloads = list(incoming_folder.iterdir())
+    assert len(updated_downloads) == len(downloads) - 1
+    assert download.name not in updated_downloads

--- a/tests/addition/demo_delete_detail_test.py
+++ b/tests/addition/demo_delete_detail_test.py
@@ -1,0 +1,37 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from common import hash_id
+from tests import test_constants
+
+
+@pytest.mark.django_db
+def test_demo_delete_detail(demo_api_client, mock_transmission_client, incoming_folder):
+    for download in test_constants.DOWNLOADS:
+        download.create_files(incoming_folder)
+    response = demo_api_client.delete(reverse("addition-detail", args=[hash_id("non-existent")]))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    # Nothing was actually deleted
+    assert len(list(incoming_folder.iterdir())) == len(test_constants.DOWNLOADS)
+    assert len(mock_transmission_client.TORRENT_DICT) == len(test_constants.TORRENT_DICT)
+
+
+ADDITION_LIST = [(True, a) for a in test_constants.TORRENT_DICT.values()] + [
+    (False, a) for a in test_constants.DOWNLOADS
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_torrent,addition", ADDITION_LIST)
+def test_demo_delete_detail_validate_all_cases(
+    demo_api_client, mock_transmission_client, incoming_folder, is_torrent, addition
+):
+    for download in test_constants.DOWNLOADS:
+        download.create_files(incoming_folder)
+
+    response = demo_api_client.delete(reverse("addition-detail", args=[addition.external_id]))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    # Nothing was actually deleted
+    assert len(list(incoming_folder.iterdir())) == len(test_constants.DOWNLOADS)
+    assert len(mock_transmission_client.TORRENT_DICT) == len(test_constants.TORRENT_DICT)

--- a/tests/addition/demo_get_detail_test.py
+++ b/tests/addition/demo_get_detail_test.py
@@ -1,0 +1,31 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from common import hash_id
+from tests import test_models
+
+
+@pytest.mark.django_db
+def test_demo_get_detail(demo_api_client):
+    response = demo_api_client.get(reverse("addition-detail", args=[hash_id("non-existent")]))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == test_models.Torrent(
+        id="non-existent",
+        name="demo_addition_1",
+        progress=50.0,
+    ).get_json(include_files=False)
+
+
+@pytest.mark.django_db
+def test_demo_get_list_to_get_detail(demo_api_client):
+    list_response = demo_api_client.get(reverse("addition-list"))
+    assert list_response.status_code == status.HTTP_200_OK
+    first_addition = list_response.data["results"][0]
+    detail_response = demo_api_client.get(reverse("addition-detail", args=[first_addition["id"]]))
+    assert detail_response.status_code == status.HTTP_200_OK
+    assert detail_response.data == test_models.Torrent(
+        id="demo_addition_1",
+        name="demo_addition_1",
+        progress=50.0,
+    ).get_json(include_files=False)

--- a/tests/addition/get_detail_test.py
+++ b/tests/addition/get_detail_test.py
@@ -1,0 +1,31 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from common import hash_id
+from tests import test_constants
+
+
+def expected_results(id_: str = test_constants.SINGLE_DOWNLOAD.id) -> dict:
+    torrents = [torrent.get_json() for torrent in test_constants.TORRENT_DICT.values()]
+    downloaded = [completed.get_json() for completed in test_constants.DOWNLOADS]
+    for addition in downloaded + torrents:
+        if addition["id"] == id_:
+            return addition
+    raise LookupError(f"no test instance exists with id: {id_}")
+
+
+@pytest.mark.django_db
+def test_get_detail(api_client, incoming_folder):
+    for download in test_constants.DOWNLOADS:
+        download.create_files(incoming_folder)
+    response = api_client.get(reverse("addition-detail", args=[test_constants.SINGLE_DOWNLOAD.id]))
+    assert response.status_code == status.HTTP_200_OK
+    expected = expected_results()
+    assert response.data == expected
+
+
+@pytest.mark.django_db
+def test_get_detail_not_found(api_client):
+    response = api_client.get(reverse("addition-detail", args=[hash_id("non-existent")]))
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/addition/get_detail_test.py
+++ b/tests/addition/get_detail_test.py
@@ -6,7 +6,7 @@ from common import hash_id
 from tests import test_constants
 
 
-def expected_results(id_: str = test_constants.SINGLE_DOWNLOAD.id) -> dict:
+def expected_results(id_: str = test_constants.SINGLE_DOWNLOAD.external_id) -> dict:
     torrents = [torrent.get_json() for torrent in test_constants.TORRENT_DICT.values()]
     downloaded = [completed.get_json() for completed in test_constants.DOWNLOADS]
     for addition in downloaded + torrents:
@@ -19,7 +19,7 @@ def expected_results(id_: str = test_constants.SINGLE_DOWNLOAD.id) -> dict:
 def test_get_detail(api_client, incoming_folder):
     for download in test_constants.DOWNLOADS:
         download.create_files(incoming_folder)
-    response = api_client.get(reverse("addition-detail", args=[test_constants.SINGLE_DOWNLOAD.id]))
+    response = api_client.get(reverse("addition-detail", args=[test_constants.SINGLE_DOWNLOAD.external_id]))
     assert response.status_code == status.HTTP_200_OK
     expected = expected_results()
     assert response.data == expected

--- a/tests/addition/get_list_test.py
+++ b/tests/addition/get_list_test.py
@@ -63,3 +63,6 @@ def test_exclude_partials(api_client, incoming_folder, mock_transmission_client,
     assert response.status_code == status.HTTP_200_OK
     assert response.data.get("count") == 0
     assert response.data.get("results") == []
+
+
+# TODO: Add test combining list and detail calls

--- a/tests/addition/get_list_test.py
+++ b/tests/addition/get_list_test.py
@@ -65,4 +65,12 @@ def test_exclude_partials(api_client, incoming_folder, mock_transmission_client,
     assert response.data.get("results") == []
 
 
-# TODO: Add test combining list and detail calls
+@pytest.mark.django_db
+def test_get_list_to_get_detail(api_client):
+    list_response = api_client.get(reverse("addition-list"))
+    assert list_response.status_code == status.HTTP_200_OK
+    assert list_response.data["count"] == len(test_constants.TORRENT_DICT)
+    first_addition = list_response.data["results"][0]
+    detail_response = api_client.get(reverse("addition-detail", args=[first_addition["id"]]))
+    assert detail_response.status_code == status.HTTP_200_OK
+    assert detail_response.data == first_addition

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 
 import pytest
@@ -46,11 +47,15 @@ class MockTransmission:
     def get_torrents(cls) -> list[test_models.Torrent]:
         return [torrent for torrent in cls.TORRENT_DICT.values()]
 
+    @classmethod
+    def remove_torrent(cls, torrent_id: int, **_):
+        del cls.TORRENT_DICT[str(torrent_id)]
+
 
 @pytest.fixture(autouse=True)
 def mock_transmission_client(monkeypatch):
     # Reset client contents for every test
-    MockTransmission.TORRENT_DICT = test_constants.TORRENT_DICT
+    MockTransmission.TORRENT_DICT = copy.deepcopy(test_constants.TORRENT_DICT)
     monkeypatch.setattr(clients.Transmission, "_client", MockTransmission)
     return MockTransmission
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,8 @@ class MockTransmission:
 
 @pytest.fixture(autouse=True)
 def mock_transmission_client(monkeypatch):
+    # Reset client contents for every test
+    MockTransmission.TORRENT_DICT = test_constants.TORRENT_DICT
     monkeypatch.setattr(clients.Transmission, "_client", MockTransmission)
     return MockTransmission
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -15,11 +15,14 @@ TORRENT_DICT = {
 }
 
 
+SINGLE_DOWNLOAD = Download(
+    name="cat-dog.mkv",
+    single_file=True,
+)
+
+
 DOWNLOADS = [
-    Download(
-        name="cat-dog.mkv",
-        single_file=True,
-    ),
+    SINGLE_DOWNLOAD,
     Download(
         name="downloaded-content",
         files=[

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -19,18 +19,19 @@ SINGLE_DOWNLOAD = Download(
     name="cat-dog.mkv",
     single_file=True,
 )
+DIR_DOWNLOAD = Download(
+    name="downloaded-content",
+    files=[
+        DownloadFile(name="poster.jpg", file_type=enums.FileType.IMAGE),
+        DownloadFile(name="subtitles.srt", file_type=enums.FileType.SUBTITLE),
+        DownloadFile(name="videos/completed.mov", file_type=enums.FileType.VIDEO),
+    ],
+)
 
 
 DOWNLOADS = [
     SINGLE_DOWNLOAD,
-    Download(
-        name="downloaded-content",
-        files=[
-            DownloadFile(name="poster.jpg", file_type=enums.FileType.IMAGE),
-            DownloadFile(name="subtitles.srt", file_type=enums.FileType.SUBTITLE),
-            DownloadFile(name="videos/completed.mov", file_type=enums.FileType.VIDEO),
-        ],
-    ),
+    DIR_DOWNLOAD,
 ]
 
 USER_USERNAME = "test"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ class Torrent:
         )
 
     @property
-    def id_formatted(self) -> str:
+    def external_id(self) -> str:
         return str(hash_id(self.id))
 
     def get_json(self, include_files=True) -> dict:
@@ -39,7 +39,7 @@ class Torrent:
         if include_files:
             files = self.files()
         return {
-            "id": self.id_formatted,
+            "id": self.external_id,
             "state": enums.State.DOWNLOADING,
             "name": self.name,
             "progress": self.progress / 100,
@@ -72,7 +72,7 @@ class Download:
     files: list[DownloadFile] = field(default=[])
 
     @property
-    def id(self) -> str:
+    def external_id(self) -> str:
         return str(hash_id(self.name))
 
     def get_json(self) -> dict:
@@ -83,7 +83,7 @@ class Download:
         else:
             files = [file.get_json() for file in self.files]
         return {
-            "id": self.id,
+            "id": self.external_id,
             "state": enums.State.COMPLETED,
             "name": self.name,
             "progress": 1.0,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ from attrs import define, field
 from transmission_rpc.lib_types import File as TorrentFile
 
 from addition import enums
+from common import hash_id
 
 
 @define
@@ -29,12 +30,16 @@ class Torrent:
             selected=True,
         )
 
+    @property
+    def id_formatted(self) -> str:
+        return str(hash_id(self.id))
+
     def get_json(self, include_files=True) -> dict:
         files = []
         if include_files:
             files = self.files()
         return {
-            "id": self.id,
+            "id": self.id_formatted,
             "state": enums.State.DOWNLOADING,
             "name": self.name,
             "progress": self.progress / 100,
@@ -66,6 +71,10 @@ class Download:
     single_file: bool = field(default=False)
     files: list[DownloadFile] = field(default=[])
 
+    @property
+    def id(self) -> str:
+        return str(hash_id(self.name))
+
     def get_json(self) -> dict:
         if self.single_file:
             files = [
@@ -74,7 +83,7 @@ class Download:
         else:
             files = [file.get_json() for file in self.files]
         return {
-            "id": self.name,
+            "id": self.id,
             "state": enums.State.COMPLETED,
             "name": self.name,
             "progress": 1.0,


### PR DESCRIPTION
Added the detail endpoint for Addition. Most complex aspect was having to implement enough of the Django model features to satisfy how DRF expects to use models and their instances. Some notable changes:
* Having to switch the generic `ObjectSet` to be a specific `AdditionSet` so that it can track what model it is transferring around.
* Adding a proper uuid id value that is the hash of either the torrent_id from Transmission or the hash of the file/directory name from the File System. This makes the detail endpoint much more predictable in what the url text will be.
    * This shouldn't be a backwards breaking change since the app currently expects pulls in a string from the list endpoint for the id, but will now be a uuid string that it'll have to switch to for be able to interact with this and future endpoints.

The endpoint itself is a RetrieveDestroyView. It is fully protected for demo users and fully functional for both torrent and file Additions.

* Resolves #9 