### PR TITLE
Rename TV Season Endpoint

### DIFF
--- a/addition/clients.py
+++ b/addition/clients.py
@@ -77,6 +77,7 @@ def delete_dir(directory: pathlib.Path) -> typing.Callable:
 class FileSystem:
 
     MOVIES_FOLDER = "Movies"
+    TV_SHOWS_FOLDER = "TV"
 
     @classmethod
     def get_files(cls) -> models.AdditionSet[models.Addition]:
@@ -139,6 +140,29 @@ class FileSystem:
                 raise ValueError(f"File does not exist: {file.current_name}")
 
         destination_folder.mkdir()
+        for file in files:
+            (addition / file.current_name).rename(destination_folder / file.new_name)
+
+        cls.clear_empty_dir(addition)
+
+    @classmethod
+    def rename_and_move_tv_season(cls, addition_name: str, title: str, season: int, files: list[models.RenameFile]):
+        addition = pathlib.Path(settings.INCOMING_FOLDER) / addition_name
+        destination_folder = (
+            pathlib.Path(settings.PLEX_FOLDER) / cls.TV_SHOWS_FOLDER / title / f"Season {'{:02d}'.format(season)}"
+        )
+        if addition.is_file():
+            if len(files) != 1:
+                raise ValueError("Addition was determined to be a file, but not just 1 file rename was provided")
+            destination_folder.mkdir(parents=True, exist_ok=True)
+            addition.rename(destination_folder / files[0].new_name)
+            return
+
+        for file in files:
+            if not (addition / file.current_name).is_file():
+                raise ValueError(f"File does not exist: {file.current_name}")
+
+        destination_folder.mkdir(parents=True, exist_ok=True)
         for file in files:
             (addition / file.current_name).rename(destination_folder / file.new_name)
 

--- a/bakus_service/urls.py
+++ b/bakus_service/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
 from knox import views as knox_views
@@ -26,6 +27,11 @@ urlpatterns = [
     path("api/v1/addition/<uuid:id>/", views.AdditionDetailView.as_view(), name="addition-detail"),
     path(
         "api/v1/addition/<uuid:id>/rename-movie", views.AdditionRenameMovieView.as_view(), name="addition-rename-movie"
+    ),
+    path(
+        "api/v1/addition/<uuid:id>/rename-tv-season",
+        views.AdditionRenameTvSeasonView.as_view(),
+        name="addition-rename-tv-season",
     ),
     path("api/v1/auth/account/", views.AccountView.as_view(), name="account-detail"),
     path("api/v1/auth/login/", views.LoginView.as_view(), name="knox_login"),

--- a/tests/addition/demo_post_rename_tv_season_test.py
+++ b/tests/addition/demo_post_rename_tv_season_test.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from addition.clients import FileSystem
+from tests import test_constants
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("delete_rest", [False, True])
+def test_nothing_changes(demo_api_client, incoming_folder, plex_folder, delete_rest):
+    test_constants.SINGLE_DOWNLOAD.create_files(incoming_folder)
+    payload = {
+        "title": test_constants.SINGLE_TITLE,
+        "season": 1,
+        "delete_rest": delete_rest,
+        "files": [
+            {
+                "current_name": test_constants.SINGLE_DOWNLOAD.name,
+                "new_name": f"{test_constants.SINGLE_TITLE}.mkv",
+            }
+        ],
+    }
+    response = demo_api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.SINGLE_DOWNLOAD.external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == payload
+
+    old_file = incoming_folder / test_constants.SINGLE_DOWNLOAD.name
+    assert old_file.exists() and old_file.is_file(), "old file should still be there"
+    new_file = (
+        plex_folder
+        / FileSystem.TV_SHOWS_FOLDER
+        / test_constants.SINGLE_TITLE
+        / "Season 01"
+        / f"{test_constants.SINGLE_TITLE}.mkv"
+    )
+    assert not new_file.exists(), "file should not have moved here"

--- a/tests/addition/file_system_client_test.py
+++ b/tests/addition/file_system_client_test.py
@@ -104,7 +104,7 @@ def test_rename_and_move_tv_season_multiple_files(incoming_folder, plex_folder):
 
     assert not (incoming_folder / old_name).exists(), "old folder should no longer exist"
     for file in files:
-        new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "season 01" / file.new_name
+        new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01" / file.new_name
         assert new_file.exists()
         assert new_file.read_text() == "foo bar"
 

--- a/tests/addition/file_system_client_test.py
+++ b/tests/addition/file_system_client_test.py
@@ -63,3 +63,133 @@ def test_rename_and_move_movie_left_over_files(incoming_folder, plex_folder):
     new_file = plex_folder / FileSystem.MOVIES_FOLDER / new_title / file_to_move.new_name
     assert new_file.exists()
     assert new_file.read_text() == "foo"
+
+
+def test_rename_and_move_tv_season_single_file(incoming_folder, plex_folder):
+    old_name = "test.mkv"
+    new_title = "Final (year)"
+    new_name = f"{new_title}.mkv"
+    file = models.RenameFile(current_name=old_name, new_name=new_name)
+    (incoming_folder / old_name).write_text("foo bar")
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 1, [file])
+
+    assert not (incoming_folder / old_name).exists(), "old file should no longer exist"
+
+    new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01" / new_name
+    assert new_file.exists()
+    assert new_file.read_text() == "foo bar"
+
+
+def test_rename_and_move_tv_season_multiple_files(incoming_folder, plex_folder):
+    old_name = "test_dir"
+    new_title = "Final (year)"
+    files = [
+        # common patterns
+        models.RenameFile(current_name="movie.mp4", new_name=f"{new_title}.mp4"),
+        models.RenameFile(current_name="other.srt", new_name=f"{new_title}.en.srt"),
+        models.RenameFile(current_name="spanish.srt", new_name=f"{new_title}.es.srt"),
+        # allow extension changes
+        models.RenameFile(current_name="sample.mp4", new_name="sample.mkv"),
+        # move nested files
+        models.RenameFile(current_name="videos/trailer.mp4", new_name="trailer.mp4"),
+    ]
+
+    for file in files:
+        old_file = incoming_folder / old_name / file.current_name
+        old_file.parent.mkdir(parents=True, exist_ok=True)
+        old_file.write_text("foo bar")
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 1, files)
+
+    assert not (incoming_folder / old_name).exists(), "old folder should no longer exist"
+    for file in files:
+        new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "season 01" / file.new_name
+        assert new_file.exists()
+        assert new_file.read_text() == "foo bar"
+
+
+def test_rename_and_move_tv_season_left_over_files(incoming_folder, plex_folder):
+    old_name = "test_dir"
+    new_title = "Final (year)"
+    file_to_move = models.RenameFile(current_name="movie.mp4", new_name=f"{new_title}.mp4")
+    file_to_leave = incoming_folder / old_name / "info.txt"
+    file_to_leave.parent.mkdir()
+
+    (incoming_folder / old_name / file_to_move.current_name).write_text("foo")
+    file_to_leave.write_text("bar")
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 1, [file_to_move])
+
+    assert file_to_leave.exists()
+    assert file_to_leave.read_text() == "bar"
+    new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01" / file_to_move.new_name
+    assert new_file.exists()
+    assert new_file.read_text() == "foo"
+
+
+def test_rename_and_move_tv_season_season_zero(incoming_folder, plex_folder):
+    old_name = "test.mkv"
+    new_title = "Final (year)"
+    new_name = f"{new_title}.mkv"
+    file = models.RenameFile(current_name=old_name, new_name=new_name)
+    (incoming_folder / old_name).write_text("foo bar")
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 0, [file])
+
+    assert not (incoming_folder / old_name).exists(), "old file should no longer exist"
+
+    new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 00" / new_name
+    assert new_file.exists()
+    assert new_file.read_text() == "foo bar"
+
+
+def test_rename_and_move_tv_season_season_already_exists_single_file(incoming_folder, plex_folder):
+    old_name = "test.mkv"
+    new_title = "Final (year)"
+    new_name = f"{new_title}.mkv"
+    file = models.RenameFile(current_name=old_name, new_name=new_name)
+    (incoming_folder / old_name).write_text("foo bar")
+
+    season_folder = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01"
+    season_folder.mkdir(parents=True)
+    (season_folder / "ep1.mkv").write_text("existing episode")
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 1, [file])
+
+    assert not (incoming_folder / old_name).exists(), "old file should no longer exist"
+
+    new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01" / new_name
+    assert new_file.exists()
+    assert new_file.read_text() == "foo bar"
+
+
+def test_rename_and_move_tv_season_season_already_exists_multiple_files(incoming_folder, plex_folder):
+    old_name = "test_dir"
+    new_title = "Final (year)"
+    files = [
+        # common patterns
+        models.RenameFile(current_name="movie.mp4", new_name=f"{new_title}.mp4"),
+        models.RenameFile(current_name="other.srt", new_name=f"{new_title}.en.srt"),
+        models.RenameFile(current_name="spanish.srt", new_name=f"{new_title}.es.srt"),
+        # allow extension changes
+        models.RenameFile(current_name="sample.mp4", new_name="sample.mkv"),
+        # move nested files
+        models.RenameFile(current_name="videos/trailer.mp4", new_name="trailer.mp4"),
+    ]
+
+    for file in files:
+        old_file = incoming_folder / old_name / file.current_name
+        old_file.parent.mkdir(parents=True, exist_ok=True)
+        old_file.write_text("foo bar")
+
+    season_folder = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01"
+    season_folder.mkdir(parents=True)
+
+    FileSystem.rename_and_move_tv_season(old_name, new_title, 1, files)
+
+    assert not (incoming_folder / old_name).exists(), "old folder should no longer exist"
+    for file in files:
+        new_file = season_folder / file.new_name
+        assert new_file.exists()
+        assert new_file.read_text() == "foo bar"

--- a/tests/addition/file_system_client_test.py
+++ b/tests/addition/file_system_client_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from addition import models
 from addition.clients import FileSystem
 
@@ -65,6 +67,31 @@ def test_rename_and_move_movie_left_over_files(incoming_folder, plex_folder):
     assert new_file.read_text() == "foo"
 
 
+def test_rename_and_move_movie_incorrect_file_count(incoming_folder):
+    old_file = "test.mkv"
+    (incoming_folder / old_file).write_text("foo bar")
+    files_to_move = [
+        models.RenameFile(current_name="movie.mp4", new_name="movie.mp4"),
+        models.RenameFile(current_name="other.srt", new_name="other.srt"),
+    ]
+
+    with pytest.raises(
+        ValueError, match="Addition was determined to be a file, but not just 1 file rename was provided"
+    ):
+        FileSystem.rename_and_move_movie(old_file, "Final (year)", files_to_move)
+
+
+def test_rename_and_move_movie_file_does_not_exist(incoming_folder):
+    old_name = "test_dir"
+    (incoming_folder / old_name).mkdir()
+    files_to_move = [
+        models.RenameFile(current_name="movie.mp4", new_name="movie.mp4"),
+    ]
+
+    with pytest.raises(ValueError, match="File does not exist: movie.mp4"):
+        FileSystem.rename_and_move_movie(old_name, "Final (year)", files_to_move)
+
+
 def test_rename_and_move_tv_season_single_file(incoming_folder, plex_folder):
     old_name = "test.mkv"
     new_title = "Final (year)"
@@ -126,6 +153,31 @@ def test_rename_and_move_tv_season_left_over_files(incoming_folder, plex_folder)
     new_file = plex_folder / FileSystem.TV_SHOWS_FOLDER / new_title / "Season 01" / file_to_move.new_name
     assert new_file.exists()
     assert new_file.read_text() == "foo"
+
+
+def test_rename_and_move_tv_season_incorrect_file_count(incoming_folder):
+    old_file = "test.mkv"
+    (incoming_folder / old_file).write_text("foo bar")
+    files_to_move = [
+        models.RenameFile(current_name="movie.mp4", new_name="movie.mp4"),
+        models.RenameFile(current_name="other.srt", new_name="other.srt"),
+    ]
+
+    with pytest.raises(
+        ValueError, match="Addition was determined to be a file, but not just 1 file rename was provided"
+    ):
+        FileSystem.rename_and_move_tv_season(old_file, "Final (year)", 1, files_to_move)
+
+
+def test_rename_and_move_tv_season_file_does_not_exist(incoming_folder):
+    old_name = "test_dir"
+    (incoming_folder / old_name).mkdir()
+    files_to_move = [
+        models.RenameFile(current_name="movie.mp4", new_name="movie.mp4"),
+    ]
+
+    with pytest.raises(ValueError, match="File does not exist: movie.mp4"):
+        FileSystem.rename_and_move_tv_season(old_name, "Final (year)", 1, files_to_move)
 
 
 def test_rename_and_move_tv_season_season_zero(incoming_folder, plex_folder):

--- a/tests/addition/post_rename_movie_test.py
+++ b/tests/addition/post_rename_movie_test.py
@@ -161,4 +161,22 @@ def test_multiple_files_clear_old(api_client, incoming_folder, plex_folder):
         assert not old_file.exists(), "file should no longer be in old location"
 
 
-# TODO: Add test for assuring in-progress Additions cannot be renamed
+@pytest.mark.django_db
+def test_rename_addition_in_progress_fails(api_client):
+    payload = {
+        "title": test_constants.DIR_TITLE,
+        "delete_rest": True,
+        "files": [
+            {
+                "current_name": "old_file.mkv",
+                "new_name": "file.mov",
+            }
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-movie", args=[test_constants.TORRENT_DICT["1"].external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data == {"detail": "Addition asked for is not marked Completed"}

--- a/tests/addition/post_rename_tv_season_test.py
+++ b/tests/addition/post_rename_tv_season_test.py
@@ -1,0 +1,175 @@
+import json
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from addition import enums
+from addition.clients import FileSystem
+from tests import test_constants
+
+
+@pytest.mark.django_db
+def test_single_file(api_client, incoming_folder, plex_folder):
+    test_constants.SINGLE_DOWNLOAD.create_files(incoming_folder)
+    payload = {
+        "title": test_constants.SINGLE_TITLE,
+        "season": 1,
+        "files": [
+            {
+                "current_name": test_constants.SINGLE_DOWNLOAD.name,
+                "new_name": f"{test_constants.SINGLE_TITLE}.mkv",
+            }
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.SINGLE_DOWNLOAD.external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    payload["delete_rest"] = False
+    assert response.data == payload
+
+    old_file = incoming_folder / test_constants.SINGLE_DOWNLOAD.name
+    assert not old_file.exists(), "old file should no longer be there"
+    new_file = (
+        plex_folder
+        / FileSystem.TV_SHOWS_FOLDER
+        / test_constants.SINGLE_TITLE
+        / "Season 01"
+        / f"{test_constants.SINGLE_TITLE}.mkv"
+    )
+    assert new_file.exists() and new_file.is_file(), "file should now be here"
+
+
+def file_type_to_extension(file_type: enums.FileType) -> str:
+    if file_type == enums.FileType.VIDEO:
+        return "mov"
+    elif file_type == enums.FileType.SUBTITLE:
+        return "srt"
+    elif file_type == enums.FileType.IMAGE:
+        return "jpg"
+    return "txt"
+
+
+@pytest.mark.django_db
+def test_multiple_files_move_everything(api_client, incoming_folder, plex_folder):
+    test_constants.DIR_DOWNLOAD.create_files(incoming_folder)
+    payload = {
+        "title": test_constants.DIR_TITLE,
+        "season": 1,
+        "files": [
+            {
+                "current_name": file.name,
+                "new_name": f"{test_constants.DIR_TITLE}.{file_type_to_extension(file.file_type)}",
+            }
+            for file in test_constants.DIR_DOWNLOAD.files
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.DIR_DOWNLOAD.external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    payload["delete_rest"] = False
+    assert response.data == payload
+
+    old_dir = incoming_folder / test_constants.DIR_DOWNLOAD.name
+    assert not old_dir.exists(), "old dir should no longer be there"
+    for file in test_constants.DIR_DOWNLOAD.files:
+        new_file = (
+            plex_folder
+            / FileSystem.TV_SHOWS_FOLDER
+            / test_constants.DIR_TITLE
+            / "Season 01"
+            / f"{test_constants.DIR_TITLE}.{file_type_to_extension(file.file_type)}"
+        )
+        assert new_file.exists() and new_file.is_file(), "file should now be here"
+
+
+@pytest.mark.django_db
+def test_multiple_files_leave_some_behind(api_client, incoming_folder, plex_folder):
+    test_constants.DIR_DOWNLOAD.create_files(incoming_folder)
+    file_to_move = [file for file in test_constants.DIR_DOWNLOAD.files if file.file_type == enums.FileType.VIDEO][0]
+    payload = {
+        "title": test_constants.DIR_TITLE,
+        "season": 1,
+        "files": [
+            {
+                "current_name": file_to_move.name,
+                "new_name": f"{test_constants.DIR_TITLE}.mov",
+            }
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.DIR_DOWNLOAD.external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    payload["delete_rest"] = False
+    assert response.data == payload
+
+    old_dir = incoming_folder / test_constants.DIR_DOWNLOAD.name
+    assert old_dir.exists(), "old dir should be there"
+    for file in test_constants.DIR_DOWNLOAD.files:
+        new_file = (
+            plex_folder
+            / FileSystem.TV_SHOWS_FOLDER
+            / test_constants.DIR_TITLE
+            / "Season 01"
+            / f"{test_constants.DIR_TITLE}.{file_type_to_extension(file.file_type)}"
+        )
+        old_file = old_dir / file.name
+        # only the video file was sent for renaming
+        if file.file_type == enums.FileType.VIDEO:
+            assert new_file.exists() and new_file.is_file(), "file should now be here"
+            assert not old_file.exists(), "file should no longer be in old location"
+        else:
+            assert not new_file.exists(), "file should not have been moved"
+            assert old_file.exists() and old_file.is_file(), "file should have stayed in original location"
+
+
+@pytest.mark.django_db
+def test_multiple_files_clear_old(api_client, incoming_folder, plex_folder):
+    test_constants.DIR_DOWNLOAD.create_files(incoming_folder)
+    file_to_move = [file for file in test_constants.DIR_DOWNLOAD.files if file.file_type == enums.FileType.VIDEO][0]
+    payload = {
+        "title": test_constants.DIR_TITLE,
+        "season": 1,
+        "delete_rest": True,
+        "files": [
+            {
+                "current_name": file_to_move.name,
+                "new_name": f"{test_constants.DIR_TITLE}.mov",
+            }
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.DIR_DOWNLOAD.external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == payload
+
+    old_dir = incoming_folder / test_constants.DIR_DOWNLOAD.name
+    assert not old_dir.exists(), "old dir should not be there"
+    for file in test_constants.DIR_DOWNLOAD.files:
+        new_file = (
+            plex_folder
+            / FileSystem.TV_SHOWS_FOLDER
+            / test_constants.DIR_TITLE
+            / "Season 01"
+            / f"{test_constants.DIR_TITLE}.{file_type_to_extension(file.file_type)}"
+        )
+        old_file = old_dir / file.name
+        # only the video file was sent for renaming
+        if file.file_type == enums.FileType.VIDEO:
+            assert new_file.exists() and new_file.is_file(), "file should now be here"
+        assert not old_file.exists(), "file should no longer be in old location"
+
+
+# TODO: Add test for assuring in-progress Additions cannot be renamed

--- a/tests/addition/post_rename_tv_season_test.py
+++ b/tests/addition/post_rename_tv_season_test.py
@@ -172,4 +172,23 @@ def test_multiple_files_clear_old(api_client, incoming_folder, plex_folder):
         assert not old_file.exists(), "file should no longer be in old location"
 
 
-# TODO: Add test for assuring in-progress Additions cannot be renamed
+@pytest.mark.django_db
+def test_rename_addition_in_progress_fails(api_client):
+    payload = {
+        "title": test_constants.DIR_TITLE,
+        "season": 1,
+        "delete_rest": True,
+        "files": [
+            {
+                "current_name": "old_file.mkv",
+                "new_name": "file.mov",
+            }
+        ],
+    }
+    response = api_client.post(
+        reverse("addition-rename-tv-season", args=[test_constants.TORRENT_DICT["1"].external_id]),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data == {"detail": "Addition asked for is not marked Completed"}

--- a/tests/addition/serializers_test.py
+++ b/tests/addition/serializers_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from addition import enums
+from addition.models import Addition
+from addition.views import BaseAdditionRenameSerializer
+
+
+def test_base_addition_rename_serializer_update_not_implemented():
+    serializer = BaseAdditionRenameSerializer()
+    with pytest.raises(NotImplementedError):
+        serializer.update(
+            Addition(files=[], name="test", progress=1.0, state=enums.State.COMPLETED, delete=lambda: None), {}
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,9 @@ def mock_project_folders(tmp_path, settings) -> dict[str, pathlib.Path]:
     plex = tmp_path / "plex"
     plex.mkdir()
     settings.PLEX_FOLDER = plex.resolve()
-    # Setup Movies folder
+    # Setup Plex folders
     (plex / clients.FileSystem.MOVIES_FOLDER).mkdir()
+    (plex / clients.FileSystem.TV_SHOWS_FOLDER).mkdir()
     return {
         "incoming": incoming,
         "plex": plex,


### PR DESCRIPTION
Add rename tv season endpoint alongside the existing movie rename endpoint. Small differences:
* different destination folder
* inner season folder
* endpoint payload requires specifying season

This supports the request for sirseim/bakus-app-apple#20 and the actual work in sirseim/bakus-app-apple#29.